### PR TITLE
fix: install libxml2 library to docker image if dashDB service is sel…

### DIFF
--- a/app/resources/services.json
+++ b/app/resources/services.json
@@ -1,0 +1,5 @@
+{
+  "dashDb": {
+    "package": "libxml2"
+  }
+}

--- a/app/templates/Dockerfile
+++ b/app/templates/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR "/app"
 
 # Install app dependencies
 COPY package.json /app/
+RUN apt-get update \
+<% for (var index = 0; index < servicesPackages.length; index++) { -%>
+ && apt-get install -y <%- servicesPackages[index] %> \
+<% } -%>
+ && echo 'Finished installing dependencies'
 RUN cd /app; npm install --production
 
 COPY . /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "generator-ibm-core-node-express",
   "version": "0.0.73",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -4042,21 +4041,6 @@
         }
       }
     },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
     "string_decoder": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
@@ -4070,6 +4054,21 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
         }
+      }
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "stringstream": {

--- a/test/common.js
+++ b/test/common.js
@@ -37,4 +37,4 @@ exports.file = {
 exports.defaultPort = 3000;
 
 // The npm start command.
-exports.npmStart = "node server.js"
+exports.npmStart = "node server.js";

--- a/test/integration.js
+++ b/test/integration.js
@@ -15,10 +15,6 @@
  * Tests here do not stub out the subgenerators, so for the app generator
  * the real build and refresh subgenerators get called.
  */
-/**
- * Tests here do not stub out the subgenerators, so for the app generator
- * the real build and refresh subgenerators get called.
- */
 'use strict';
 const common = require('./common.js');
 const path = require('path');
@@ -26,6 +22,9 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const fs = require('fs');
 const PROJECT_NAME = "ProjectName";
+
+const scaffolderSample = require('./samples/scaffolder-sample');
+const scaffolderSampleNode = scaffolderSample.getJson('NODE');
 
 describe('core-node-express:app integration test with custom spec', function () {
   // Express build is slow so we need to set a longer timeout for the test
@@ -342,9 +341,25 @@ describe('core-node-express:app integration test with openApiServices', function
   });
 
   it('created expected endpoints', function () {
-    assert.file('server/routers/persons.js')
+    assert.file('server/routers/persons.js');
     assert.fileContent('server/routers/persons.js', 'router.get(\'/persons\', function (req, res, next) {');
-    assert.file('server/routers/dinosaurs.js')
+    assert.file('server/routers/dinosaurs.js');
     assert.fileContent('server/routers/dinosaurs.js', 'router.get(\'/dinosaurs\', function (req, res, next) {');
+  });
+});
+
+describe('core-node-express:app integration test with with dashDB', function () {
+  before(function () {
+    // Mock the options, set up an output folder and run the generator
+    return helpers.run(path.join( __dirname, '../app'))
+      .withOptions({
+        bluemix: scaffolderSampleNode
+      })
+      .toPromise(); // Get a Promise back when the generator finishes
+  });
+
+  it('create Dockerfile for running', function () {
+    assert.file(['Dockerfile', 'cli-config.yml', 'Dockerfile-tools']);
+    assert.fileContent('Dockerfile', '&& apt-get install -y libxml2 \\');
   });
 });

--- a/test/samples/scaffolder-sample-contents.js
+++ b/test/samples/scaffolder-sample-contents.js
@@ -1,0 +1,334 @@
+/*
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// class used by scaffolder-sample.js to build scaffolder objects for testing
+
+class scaffolderSample {
+  fullContents() {
+    return {
+      "analytics": {
+        "apiKey": "ff12d70f-78bc-4db3-8d02-9c076996d15f",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        }
+      },
+      "server": {
+        "diskQuota": "512M",
+        "domain": "ng.bluemix.net",
+        "env": {
+          "JAVA_HOME": "PATH/TO/JAVAC",
+          "ANT_OPTS": "ANTOPTSGOHERE"
+        },
+        "host": "myapp",
+        "instances": 3,
+        "memory": "1024M",
+        "name": "my-application",
+        "organization": "IMF_Sand",
+        "services": [
+          "example-service", "example-service2"
+        ],
+        "space": "mobilecategoryDev"
+      },
+      "auth": {
+        "clientId": "2212d70f-78bc-4db3-8d02-9c076996d15f",
+        "oauthServerUrl": "https://appid-oauth.ng.bluemix.net/oauth/v3/{tenantId}",
+        "profilesUrl": "https://appid-profiles.ng.bluemix.net",
+        "secret": "ABCD1234ABCD1234",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "tenantId": "1112d70f-78bc-4db3-8d02-9c076996d15f",
+        "version": "3"
+      },
+      "cloudant": [
+        {
+          "password": "pass",
+          "serviceInfo": {
+            "label": "MyAnalyticsLabel",
+            "name": "MyAnalyticsService",
+            "plan": "Basic"
+          },
+          "url": "https://account.cloudant.com",
+          "username": "user"
+        }
+      ],
+      "conversation": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/conversation/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "dashDb": {
+        "db": "BLUDB",
+        "dsn": "DATABASE=BLUDB;HOSTNAME=ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net;PORT=50000;PROTOCOL=TCPIP;UID=dash105642;PWD=_qFv_9yCH8Al;",
+        "host": "ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net",
+        "hostname": "ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net",
+        "https_url": "https://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:8443",
+        "jdbcurl": "jdbc:db2://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50000/BLUDB",
+        "password": "_qFv_9yCH8Al",
+        "port": 50000,
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "ssldsn": "DATABASE=BLUDB;HOSTNAME=ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net;PORT=50001;PROTOCOL=TCPIP;UID=dash105642;PWD=_qFv_9yCH8Al;Security=SSL;",
+        "ssljdbcurl": "jdbc:db2://ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50001/BLUDB:sslConnection=true;",
+        "uri": "db2://dash105642:_qFv_9yCH8Al@ys1-dashdb-small-bm01-im-dal06-env4.services.dal.bluemix.net:50000/BLUDB",
+        "username": "dash105642"
+      },
+      "discovery": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/discovery/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "documentConversion": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/document-conversion/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "languageTranslator": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/language-translator/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "name": "AcmeProject",
+      "naturalLanguageClassifier": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/natural-language-classifier/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "naturalLanguageUnderstanding": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/natural-language-understanding/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "objectStorage": [
+        {
+          "auth_url": "https://identity.open.softlayer.com",
+          "domainId": "theDomainId",
+          "domainName": "theDomainName",
+          "password": "Gl.=W23@",
+          "project": "theProjectName",
+          "projectId": "12345",
+          "region": "dallas",
+          "role": "admin",
+          "serviceInfo": {
+            "label": "MyAnalyticsLabel",
+            "name": "MyAnalyticsService",
+            "plan": "Basic"
+          },
+          "userId": "abc1234",
+          "username": "user"
+        }
+      ],
+      "personalityInsights": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/personality-insights/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "push": {
+        "appGuid": "ac35d70f-98bc-4db3-8d02-9c07699615f0",
+        "appSecret": "d3017301-0285-4312-9aa0-c3f5b8289add",
+        "clientSecret": "c13bcd73-352e-44d8-a7bc-6f2546eec711",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        }
+      },
+      "retrieveAndRank": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/retrieve-and-rank/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "sdks": [
+        {
+          "name": "PetStore",
+          "spec": "http://petstore.swagger.io/v2/swagger.json"
+        }
+      ],
+      "speechToText": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/speech-to-text/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "textToSpeech": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/text-to-speech/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "toneAnalyzer": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/tone-analyzer/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "tradeoffAnalytics": {
+        "password": "IDgoZXBCGsDe",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/tradeoff-analytics/api",
+        "username": "0ec0f025-54r2-4e84-944f-8224a66217f2"
+      },
+      "visualRecognition": {
+        "api_key": "IDgoZXBCGsDe",
+        "note": "This apiKey will be valid in an hour or so.",
+        "serviceInfo": {
+          "label": "MyAnalyticsLabel",
+          "name": "MyAnalyticsService",
+          "plan": "Basic"
+        },
+        "url": "https://gateway.watsonplatform.net/visual-recognition/api"
+      },
+      "mongodb": {
+        "uri": "mongodb://admin:password@bluemix.net,bluemix.net:20056/compose?ssl=true&authSource=admin"
+      },
+      "postgresql": {
+        "uri": "postgres://admin:password@bluemix.net:20058/compose"
+      },
+      "alertnotification": {
+        "url": "https://bluemix.net",
+        "name": "alertnotification",
+        "password": "alertnotification-password"
+      },
+      "redis": {
+        "uri": "redis://admin:password@bluemix.com:20051"
+      }
+    }
+  }
+
+  noServices() {
+    return {
+      "name": "AcmeProject",
+      "server": {
+        "diskQuota": "512M",
+        "domain": "ng.bluemix.net",
+        "env": {
+          "JAVA_HOME": "PATH/TO/JAVAC",
+          "ANT_OPTS": "ANTOPTSGOHERE"
+        },
+        "host": "myapp",
+        "instances": 3,
+        "memory": "1024M",
+        "name": "my-application",
+        "organization": "IMF_Sand",
+        "services": [
+          "example-service", "example-service2"
+        ],
+        "space": "mobilecategoryDev"
+      }
+    }
+  }
+
+  noServer() {
+    return {
+      "name": "AcmeProject"
+    }
+  }
+
+  serverDeployment(deploymentType) {
+    let bluemix = {
+      "name": "AcmeProject",
+      "server": {
+        "diskQuota": "512M",
+        "domain": "ng.bluemix.net",
+        "host": "myapp",
+        "instances": 3,
+        "memory": "1024M",
+        "name": "my-application",
+        "organization": "IMF_Sand",
+        "space": "mobilecategoryDev"
+      }
+    };
+
+    if (deploymentType) {
+      bluemix.server.cloudDeploymentType = deploymentType;
+      if (deploymentType === 'Kube') {
+        bluemix.server.cloudDeploymentOptions = {
+          kubeClusterName: 'my_kube_cluster',
+          kubeClusterNamespace: 'my_kube_namespace'
+        };
+      }
+    }
+
+    return bluemix;
+  }
+}
+
+module.exports = {
+  scaffolderSample : scaffolderSample
+};

--- a/test/samples/scaffolder-sample.js
+++ b/test/samples/scaffolder-sample.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const sample = require('./scaffolder-sample-contents');
+
+function getJson(language) {
+  let scaffolderSample = new sample.scaffolderSample();
+  let bluemix = scaffolderSample.fullContents();
+  return get(language, bluemix);
+}
+
+function getJsonNoServices(language) {
+  let scaffolderSample = new sample.scaffolderSample();
+  let bluemix = scaffolderSample.noServices();
+  return get(language, bluemix);
+}
+
+function getJsonNoServer(language) {
+  let scaffolderSample = new sample.scaffolderSample();
+  let bluemix = scaffolderSample.noServer();
+  return get(language, bluemix);
+}
+
+function getJsonServerWithDeployment(language, deploymentType) {
+  let scaffolderSample = new sample.scaffolderSample();
+  let bluemix = scaffolderSample.serverDeployment(deploymentType);
+  return get(language, bluemix);
+}
+
+function get(language, bluemix) {
+  bluemix.backendPlatform = language;
+  return JSON.stringify(bluemix);
+}
+
+module.exports = {
+  getJson : getJson,
+  getJsonNoServices : getJsonNoServices,
+  getJsonNoServer : getJsonNoServer,
+  getJsonServerWithDeployment: getJsonServerWithDeployment
+};


### PR DESCRIPTION
…ected

Adding the `dashDB` service results in this error after performing a `bx dev build && bx dev run`:

```
[INFO] ibm-cloud-env - Initializing with /app/server/config/mappings.json
/app/node_modules/bindings/bindings.js:83
        throw e
        ^

Error: libxml2.so.2: cannot open shared object file: No such file or directory
    at Error (native)
    at Object.Module._extensions..node (module.js:597:18)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at Module.newFunc (/app/node_modules/appmetrics/lib/aspect.js:101:26)
    at require (internal/module.js:20:19)
    at bindings (/app/node_modules/bindings/bindings.js:76:44)
    at Object.<anonymous> (/app/node_modules/ibm_db/lib/odbc.js:31:31)
```

We need to install the `libxml2` library and add it to the **Dockerfile** for Node to avoid this error. I tried to be consistent with the other parts of the code, but let me know if I did this correctly / any other updates need to be made.

Thanks!

(Related: https://github.com/ibm-developer/generator-ibm-cloud-enablement/pull/143)