### PR TITLE
feat(version): updating to Node v8

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -4,7 +4,7 @@
   "description": "A generated IBM Cloud application",
   "private": true,
   "engines": {
-    "node": "^6.9.0"
+    "node": "^8.11.1"
   },
   "scripts": {
     "start": "node server/server.js",

--- a/test/integration.js
+++ b/test/integration.js
@@ -78,7 +78,7 @@ describe('core-node-express:app integration test with custom spec', function () 
         "description": "A generated IBM Cloud application",
         "private": true,
         "engines": {
-          "node": "^6.9.0"
+          "node": "^8.11.1"
         },
         "scripts": {
           "start": "node server/server.js",
@@ -169,7 +169,7 @@ describe('core-node-express:app integration test with custom bluemix.fromYo flag
         "description": "A generated IBM Cloud application",
         "private": true,
         "engines": {
-          "node": "^6.9.0"
+          "node": "^8.11.1"
         },
         "scripts": {
           "start": "node server/server.js",
@@ -279,7 +279,7 @@ describe('core-node-express:app integration test with custom bluemix', function 
         "description": "A generated IBM Cloud application",
         "private": true,
         "engines": {
-          "node": "^6.9.0"
+          "node": "^8.11.1"
         },
         "scripts": {
           "start": "node server/server.js",
@@ -381,7 +381,7 @@ describe('core-node-express:app integration test with custom bluemix and spec', 
         "description": "A generated IBM Cloud application",
         "private": true,
         "engines": {
-          "node": "^6.9.0"
+          "node": "^8.11.1"
         },
         "scripts": {
           "start": "node server/server.js",


### PR DESCRIPTION
Changing to Node v8 is expecting to give better runtimg performance especially for build (e.g
webpack)

BREAKING CHANGE: potential breaking changes between v6 LTS and v8 LTS
(https://github.com/nodejs/node/wiki/Breaking-changes-between-v6-LTS-and-v8-LTS)