### PR TITLE
fix: added host and port for debugger

### DIFF
--- a/app/templates/run-debug
+++ b/app/templates/run-debug
@@ -7,7 +7,7 @@ CURRENT_NPM_VERSION=$(node -e "console.log(parseFloat(\"$CURRENT_NPM_VERSION\".r
 SUPPORT_NPM_INSPECT=$(echo "$CURRENT_NPM_VERSION > 6.2" | bc -l)
 
 if [ "$SUPPORT_NPM_INSPECT" == "1" ]; then
-	node --inspect server/server.js	
+	node --inspect=0.0.0.0:9229 server/server.js	
 else
-	node --debug server/server.js	
+	node --debug=0.0.0.0:5858 server/server.js	
 fi


### PR DESCRIPTION
Docker will not connect to debugger unless the host and port are specified