### PR TITLE
fix: change debug options

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "node server/server.js",
-    "debug": "chmod +x run-debug && ./run-debug",
+    "debug": "node --inspect=0.0.0.0:9229 server/server.js",
+    "debug:legacy": "node --debug=0.0.0.0:5858 server/server.js",
     "test": "nyc mocha --exit",
     "dev": "nodemon server/server.js"
   },

--- a/test/integration.js
+++ b/test/integration.js
@@ -91,7 +91,7 @@ describe('core-node-express:app integration test with custom spec', function () 
         },
         "scripts": {
           "start": "node server/server.js",
-          "debug": "chmod +x run-debug && ./run-debug",
+          "debug": "node --inspect=0.0.0.0:9229 server/server.js",
           "test": "nyc mocha --exit"
         },
         "dependencies": {


### PR DESCRIPTION
Since we only run node 8 (maybe 10 later) while using `bx dev`, which we hard-code in CLI to run `npm run debug` for `bx dev debug`, there is no need for logic to figure out which type of debug scenario to use.