### PR TITLE
fix: add logger level to server

### DIFF
--- a/app/templates/server/server.js
+++ b/app/templates/server/server.js
@@ -11,10 +11,12 @@ const appName = require('./../package').name;
 const http = require('http');
 const express = require('express');
 const log4js = require('log4js');
+const DEFAULT_LOG_LEVEL = log4js.levels.INFO;
 const localConfig = require('./config/local.json');
 const path = require('path');
 
 const logger = log4js.getLogger(appName);
+logger.level = DEFAULT_LOG_LEVEL;
 const app = express();
 const server = http.createServer(app);
 


### PR DESCRIPTION
After updating the dependency Log4js, we need to set the logger level. This PR fixes a problem where node apps were not logging:
`[2018-11-13T17:47:12.117] [INFO] nodeweb - nodeweb listening on http://localhost:3000/appmetrics-dash
[2018-11-13T17:47:12.117] [INFO] nodeweb - nodeweb listening on http://localhost:3000

`