### PR TITLE
Add debug:brk npm script

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "node $npm_package_config_entrypoint",
     "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint",
+    "debug:brk": "node --inspect-brk=0.0.0.0:9229 $npm_package_config_entrypoint",
     "debug:legacy": "node --debug=0.0.0.0:5858 $npm_package_config_entrypoint",
     "test": "nyc mocha --exit",
     "dev": "nodemon $npm_package_config_entrypoint"


### PR DESCRIPTION
In Microclimate, we have a UI option for the user to choose whether they want their application to hit a breakpoint before any app code is run. This change will allow us to support this option for Node projects.
